### PR TITLE
fix: update extension point and bump version to 1.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "title": "Release Manager",
   "description": "Plan, track, and communicate product releases with version management, progress tracking, and release notes generation.",
   "$schema": "https://json.schemastore.org/youtrack-app.json",
-  "version": "1.2.0",
-  "changeNotes": "<h3>Version 1.2.0</h3>\n<ul>\n  <li><b>Feature:</b> Allow using multi-select custom fields in mapping</li>\n  <li><b>Feature:</b> Import custom field values as releases into the app</li>\n</ul>",
+  "version": "1.2.1",
+  "changeNotes": "<h3>Version 1.2.1</h3>\n<ul>\n  <li><b>Fix:</b> Updated widget extension point to PROJECT_TAB for correct placement in YouTrack</li>\n</ul>\n<h3>Version 1.2.0</h3>\n<ul>\n  <li><b>Feature:</b> Allow using multi-select custom fields in mapping</li>\n  <li><b>Feature:</b> Import custom field values as releases into the app</li>\n</ul>",
   "vendor": {
     "name": "E.V",
     "url": "https://github.com/ve-ev/release-manager-app"
@@ -15,7 +15,7 @@
       "key": "releases",
       "name": "Release Manager",
       "indexPath": "release-manager-page/index.html",
-      "extensionPoint": "PROJECT_SETTINGS",
+      "extensionPoint": "PROJECT_TAB",
       "iconPath": "release-manager-page/widget-icon.svg",
       "permissions": []
     }


### PR DESCRIPTION
## Summary

- Changed widget `extensionPoint` from `PROJECT_SETTINGS` to `PROJECT_TAB` for correct placement in YouTrack
- Bumped version to `1.2.1`
- Added 1.2.1 entry to `changeNotes`
