### PR TITLE
feat: onboarding tour UX improvements

### DIFF
--- a/src/widgets/release-manager-page/app.tsx
+++ b/src/widgets/release-manager-page/app.tsx
@@ -445,6 +445,7 @@ const AppComponent: React.FunctionComponent = () => {
         <EmptyState
           canCreate={permissions.canCreate}
           canAccessSettings={permissions.canAccessSettings}
+          isConfigured={hasProducts || hasProgress}
           onAddRelease={handleAddReleaseVersion}
           onOpenSettings={() => setShowSettings(true)}
         />

--- a/src/widgets/release-manager-page/app.tsx
+++ b/src/widgets/release-manager-page/app.tsx
@@ -513,7 +513,7 @@ const AppComponent: React.FunctionComponent = () => {
               {permissions.canCreate && !showEmpty && (
                 <Button primary onClick={handleAddReleaseVersion}>Add Release Version</Button>
               )}
-              {permissions.canAccessSettings && (
+              {permissions.canAccessSettings && !showEmpty && (
                 <Button
                   className="progress-settings-button"
                   onClick={() => setShowSettings(true)}

--- a/src/widgets/release-manager-page/components/empty-state.tsx
+++ b/src/widgets/release-manager-page/components/empty-state.tsx
@@ -21,6 +21,7 @@ interface OnboardingStepProps {
   onClick: () => void;
   enabled: boolean;
   primary?: boolean;
+  completed?: boolean;
 }
 
 const OnboardingStep: React.FC<OnboardingStepProps> = ({
@@ -31,9 +32,10 @@ const OnboardingStep: React.FC<OnboardingStepProps> = ({
   onClick,
   enabled,
   primary,
+  completed,
 }) => (
-  <div className={`onboarding-step${enabled ? '' : ' onboarding-step--locked'}`}>
-    <div className="onboarding-step-badge">{number}</div>
+  <div className={`onboarding-step${enabled ? '' : ' onboarding-step--locked'}${completed ? ' onboarding-step--completed' : ''}`}>
+    <div className="onboarding-step-badge">{completed ? '✓' : number}</div>
     <div className="onboarding-step-content">
       <div className="onboarding-step-title">{title}</div>
       <div className="onboarding-step-description">{description}</div>
@@ -77,6 +79,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
             actionLabel="Open Settings"
             onClick={onOpenSettings}
             enabled={canAccessSettings}
+            completed={isConfigured}
           />
           <OnboardingStep
             number={2}

--- a/src/widgets/release-manager-page/components/empty-state.tsx
+++ b/src/widgets/release-manager-page/components/empty-state.tsx
@@ -20,6 +20,7 @@ interface OnboardingStepProps {
   actionLabel: string;
   onClick: () => void;
   enabled: boolean;
+  primary?: boolean;
 }
 
 const OnboardingStep: React.FC<OnboardingStepProps> = ({
@@ -29,6 +30,7 @@ const OnboardingStep: React.FC<OnboardingStepProps> = ({
   actionLabel,
   onClick,
   enabled,
+  primary,
 }) => (
   <div className={`onboarding-step${enabled ? '' : ' onboarding-step--locked'}`}>
     <div className="onboarding-step-badge">{number}</div>
@@ -40,6 +42,7 @@ const OnboardingStep: React.FC<OnboardingStepProps> = ({
       className="onboarding-step-action"
       onClick={onClick}
       disabled={!enabled}
+      primary={primary && enabled}
     >
       {actionLabel}
     </Button>
@@ -82,6 +85,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
             actionLabel="Create Release"
             onClick={onAddRelease}
             enabled={canCreate && isConfigured}
+            primary
           />
         </div>
       </section>

--- a/src/widgets/release-manager-page/components/empty-state.tsx
+++ b/src/widgets/release-manager-page/components/empty-state.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {H1, H4} from '@jetbrains/ring-ui-built/components/heading/heading';
+import {H1} from '@jetbrains/ring-ui-built/components/heading/heading';
 import Button from '@jetbrains/ring-ui-built/components/button/button';
 import purpleShadow from '../assets/shadow-purple.svg';
 import blueShadow from '../assets/shadow-blue.svg';
@@ -8,11 +8,51 @@ import '../styles/empty-state.css';
 interface EmptyStateProps {
   canCreate: boolean;
   canAccessSettings: boolean;
+  isConfigured: boolean;
   onAddRelease: () => void;
   onOpenSettings: () => void;
 }
 
-export const EmptyState: React.FC<EmptyStateProps> = ({ canCreate, onAddRelease}) => {
+interface OnboardingStepProps {
+  number: number;
+  title: string;
+  description: string;
+  actionLabel: string;
+  onClick: () => void;
+  enabled: boolean;
+}
+
+const OnboardingStep: React.FC<OnboardingStepProps> = ({
+  number,
+  title,
+  description,
+  actionLabel,
+  onClick,
+  enabled,
+}) => (
+  <div className={`onboarding-step${enabled ? '' : ' onboarding-step--locked'}`}>
+    <div className="onboarding-step-badge">{number}</div>
+    <div className="onboarding-step-content">
+      <div className="onboarding-step-title">{title}</div>
+      <div className="onboarding-step-description">{description}</div>
+    </div>
+    <Button
+      className="onboarding-step-action"
+      onClick={onClick}
+      disabled={!enabled}
+    >
+      {actionLabel}
+    </Button>
+  </div>
+);
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  canCreate,
+  canAccessSettings,
+  isConfigured,
+  onAddRelease,
+  onOpenSettings,
+}) => {
   return (
     <div className="empty-state">
       <section className="empty-state-text">
@@ -26,24 +66,24 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ canCreate, onAddRelease}
           monitor progress, and manage related issues — all in one place.
         </div>
 
-        {canCreate && (
-        <>
-          <div className="empty-state-actions">
-            <Button primary onClick={onAddRelease}>Create your first release version</Button>
-          </div>
-          <div className="empty-state-tips">
-            <H4>Tips:</H4>
-            <ul className="empty-state-tips-list">
-              <li>Start in Settings to choose products and fields used to calculate progress.</li>
-              <li>Create a release version and, if needed, a meta‑issue to group related work.</li>
-              <li>Click a release row to open details and quick actions.</li>
-            </ul>
-          </div>
-        </>
-        )}
-
-
-
+        <div className="onboarding-steps">
+          <OnboardingStep
+            number={1}
+            title="Setup the App"
+            description="Choose products and configure progress tracking in Settings."
+            actionLabel="Open Settings"
+            onClick={onOpenSettings}
+            enabled={canAccessSettings}
+          />
+          <OnboardingStep
+            number={2}
+            title="Create your first release"
+            description="Define a version, set dates, and start tracking."
+            actionLabel="Create Release"
+            onClick={onAddRelease}
+            enabled={canCreate && isConfigured}
+          />
+        </div>
       </section>
     </div>
   );

--- a/src/widgets/release-manager-page/styles/empty-state.css
+++ b/src/widgets/release-manager-page/styles/empty-state.css
@@ -127,6 +127,10 @@
   background: var(--ring-secondary-color);
 }
 
+.onboarding-step--completed .onboarding-step-badge {
+  background: var(--ring-icon-success-color);
+}
+
 .onboarding-step-content {
   flex: 1;
   min-width: 0;
@@ -150,6 +154,7 @@
 .onboarding-step-action {
   flex-shrink: 0;
   min-height: 40px;
+  min-width: 128px;
 }
 
 /* Scale on press — only when enabled */

--- a/src/widgets/release-manager-page/styles/empty-state.css
+++ b/src/widgets/release-manager-page/styles/empty-state.css
@@ -87,3 +87,104 @@
   bottom: -36px;
   opacity: 0.9;
 }
+
+/* ── Onboarding tour ───────────────────────────── */
+
+@keyframes empty-state-enter {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Stagger the heading, subtitle, and each step on mount */
+.empty-state-text h1 {
+  animation: empty-state-enter 0.3s cubic-bezier(0.2, 0, 0, 1) both;
+  animation-delay: 0ms;
+}
+
+.empty-state-subtitle {
+  animation: empty-state-enter 0.3s cubic-bezier(0.2, 0, 0, 1) both;
+  animation-delay: 80ms;
+}
+
+.onboarding-steps {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--ring-unit) * 1.5);
+  margin-top: calc(var(--ring-unit) * 3);
+  text-align: left;
+}
+
+.onboarding-step {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--ring-unit) * 2);
+  padding: calc(var(--ring-unit) * 1.5) calc(var(--ring-unit) * 2);
+  background: var(--ring-sidebar-background-color);
+  border-radius: var(--ring-border-radius);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
+  animation: empty-state-enter 0.3s cubic-bezier(0.2, 0, 0, 1) both;
+  transition-property: opacity;
+  transition-duration: 0.2s;
+}
+
+.onboarding-step:nth-child(1) { animation-delay: 160ms; }
+.onboarding-step:nth-child(2) { animation-delay: 240ms; }
+
+.onboarding-step--locked {
+  opacity: 0.55;
+}
+
+.onboarding-step-badge {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--ring-main-color);
+  color: var(--ring-white-text-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  transition-property: background;
+  transition-duration: 0.2s;
+}
+
+.onboarding-step--locked .onboarding-step-badge {
+  background: var(--ring-secondary-color);
+}
+
+.onboarding-step-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.onboarding-step-title {
+  font-weight: 600;
+  font-size: var(--ring-font-size);
+  color: var(--ring-text-color);
+  text-wrap: balance;
+  margin: 0 0 2px;
+}
+
+.onboarding-step-description {
+  font-size: var(--ring-font-size-smaller);
+  color: var(--ring-secondary-color);
+  text-wrap: pretty;
+  margin: 0;
+}
+
+.onboarding-step-action {
+  flex-shrink: 0;
+  min-height: 40px;
+}
+
+/* Scale on press — only when enabled */
+.onboarding-step-action:not([disabled]):active {
+  transform: scale(0.96);
+  transition-property: transform;
+  transition-duration: 0.1s;
+}

--- a/src/widgets/release-manager-page/styles/empty-state.css
+++ b/src/widgets/release-manager-page/styles/empty-state.css
@@ -12,43 +12,11 @@
   width: 100%;
   text-align: center;
   background: var(--ring-content-background-color);
-  border-radius: var(--ring-border-radius);
+  border-radius: var(--ring-border-radius-large, 8px);
   padding: calc(var(--ring-unit) * 4);
   box-shadow: var(--ring-popup-shadow);
 }
 
-.empty-state-actions {
-  display: flex;
-  gap: calc(var(--ring-unit) * 2);
-  margin-top: calc(var(--ring-unit) * 2);
-  justify-content: center;
-}
-
-.empty-state-tips {
-  margin-top: calc(var(--ring-unit) * 4);
-  color: var(--ring-secondary-color);
-  text-align: center;
-  /* Match heading-like appearance for both header and list */
-  font-size: 12px;
-}
-
-/* Make the Tips header closer to the list and visually unified */
-.empty-state-tips h4 {
-  margin: 0; /* remove default bottom margin */
-}
-
-.empty-state-tips-list {
-  margin-top: calc(var(--ring-unit) * 1); /* closer to header */
-  display: inline-block; /* center the list while keeping bullet alignment */
-  text-align: left;
-  padding-left: calc(var(--ring-unit) * 3);
-  font-size: inherit; /* same font as header */
-  font-weight: inherit; /* same font weight as header */
-}
-
-.empty-state-tips-list li {
-  margin: calc(var(--ring-unit) * 0.5) 0;
-}
 
 .empty-state-subtitle {
   /* more space before actions */
@@ -120,13 +88,14 @@
   gap: calc(var(--ring-unit) * 2);
   padding: calc(var(--ring-unit) * 1.5) calc(var(--ring-unit) * 2);
   background: var(--ring-sidebar-background-color);
-  border-radius: var(--ring-border-radius);
+  border-radius: calc(var(--ring-border-radius-large, 8px) - 4px);
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.06),
     0 0 0 1px rgba(0, 0, 0, 0.05);
   animation: empty-state-enter 0.3s cubic-bezier(0.2, 0, 0, 1) both;
   transition-property: opacity;
   transition-duration: 0.2s;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
 
 .onboarding-step:nth-child(1) { animation-delay: 160ms; }
@@ -151,6 +120,7 @@
   line-height: 1;
   transition-property: background;
   transition-duration: 0.2s;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
 
 .onboarding-step--locked .onboarding-step-badge {
@@ -187,4 +157,5 @@
   transform: scale(0.96);
   transition-property: transform;
   transition-duration: 0.1s;
+  transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }


### PR DESCRIPTION
## Summary

- Step 1 badge turns green with a ✓ checkmark when settings have been saved (`isConfigured`)
- Both onboarding step buttons now share a consistent `min-width: 128px`
- Header Settings button is hidden while the onboarding empty state is visible, keeping the CTA focused on the step cards