### PR TITLE
fix: resolve localised CF bundle field name mismatch and missing Feature Freeze Date on version select

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -1704,6 +1704,41 @@ exports.httpHandler = {
             }
         },
         {
+            // Resolves a custom field by name using the App SDK (which handles localised display
+            // names). Returns the canonical field name and ID so the frontend can match the field
+            // in the YouTrack REST API regardless of the locale the user configured.
+            method: 'GET',
+            path: 'field-bundle-info',
+            scope: 'project',
+            handle: function handle(ctx) {
+                try {
+                    const fieldName = ctx.request.getParameter('fieldName');
+                    if (!fieldName) {
+                        sendErrorResponse(ctx, HTTP_STATUS.BAD_REQUEST, 'fieldName parameter is required');
+                        return;
+                    }
+                    const field = ctx.project.findFieldByName(fieldName);
+                    if (!field) {
+                        ctx.response.json({ found: false });
+                        return;
+                    }
+                    let fieldId = null;
+                    let bundleId = null;
+                    try { fieldId = field.id || null; } catch(e) {}
+                    try { bundleId = (field.bundle && field.bundle.id) || null; } catch(e) {}
+                    ctx.response.json({
+                        found: true,
+                        canonicalName: field.name || fieldName,
+                        fieldId: fieldId,
+                        bundleId: bundleId
+                    });
+                } catch (error) {
+                    logError('Failed to get field bundle info', error);
+                    sendErrorResponse(ctx, HTTP_STATUS.BAD_REQUEST, error.message || error);
+                }
+            }
+        },
+        {
             method: 'POST',
             path: 'custom-field-set',
             scope: 'project',

--- a/src/widgets/release-manager-page/api.ts
+++ b/src/widgets/release-manager-page/api.ts
@@ -226,21 +226,52 @@ export class API {
     const projectId = YTApp.entity?.type === 'project' ? (YTApp.entity.id || '') : '';
     if (!projectId) { return; }
 
+    // Step 0: resolve the canonical field name via the App SDK backend. The App SDK's
+    // findFieldByName() handles localised display names (e.g. German "Beheben in" →
+    // canonical REST API name "Fix versions"), closing the gap between what the user
+    // types in settings and what the YouTrack REST API exposes as field.name.
+    let resolvedFieldId: string | null = null;
+    let resolvedBundleId: string | null = null;
+    const lowerFieldNames = new Set([fieldName.toLowerCase()]);
+    try {
+      const info = await this.fetchJson<{
+        found: boolean;
+        canonicalName?: string;
+        fieldId?: string | null;
+        bundleId?: string | null;
+      }>(`backend/field-bundle-info?fieldName=${encodeURIComponent(fieldName)}`);
+      if (info?.found) {
+        if (info.canonicalName) { lowerFieldNames.add(info.canonicalName.toLowerCase()); }
+        if (info.fieldId) { resolvedFieldId = info.fieldId; }
+        if (info.bundleId) { resolvedBundleId = info.bundleId; }
+      }
+      logger.debug('syncVersionBundleElement: field-bundle-info', { found: info?.found, canonicalName: info?.canonicalName, fieldId: info?.fieldId, bundleId: info?.bundleId });
+    } catch (e) {
+      logger.debug('syncVersionBundleElement: field-bundle-info lookup failed, proceeding with REST API name match only');
+    }
+
     // Step 1: fetch bundle ID only (no nested values — avoids YouTrack REST default ~42-element
     // cap; $top=1000 matches step 2 for consistency). Request bundle via both projections:
     //   bundle(id)             — project-specific bundle (correct for independent copies)
-    //   field(id,name,bundle(id)) — global field definition's bundle (fallback for global bundles
-    //                             where the direct property may not be returned by some versions)
+    //   field(id,name,localizedName,bundle(id)) — also request the localised display name (e.g.
+    //     "Beheben in" for "Fix versions" on German instances; supported in YouTrack 2022.1+)
     const customFields = await this.host.fetchYouTrack<Array<{
-      field: { name: string; bundle?: { id: string } | null } | null;
+      id: string;
+      field: { id: string; name: string; localizedName?: string | null; bundle?: { id: string } | null } | null;
       bundle: { id: string } | null;
-    }>>(`admin/projects/${encodeURIComponent(projectId)}/customFields?fields=id,field(id,name,bundle(id)),bundle(id)&$top=1000`);
+    }>>(`admin/projects/${encodeURIComponent(projectId)}/customFields?fields=id,field(id,name,localizedName,bundle(id)),bundle(id)&$top=1000`);
 
-    const lowerFieldName = fieldName.toLowerCase();
-    const matched = (customFields || []).find(f => f.field?.name?.toLowerCase() === lowerFieldName);
+    // Match by canonical name, localised name (e.g. "Beheben in" == "Fix versions" in German),
+    // or by field ID from the App SDK backend — whichever resolves first.
+    const matched = (customFields || []).find(f => {
+      const n = f.field?.name?.toLowerCase() ?? '';
+      const ln = f.field?.localizedName?.toLowerCase() ?? '';
+      return lowerFieldNames.has(n) || (ln && lowerFieldNames.has(ln)) ||
+        (resolvedFieldId != null && (f.id === resolvedFieldId || f.field?.id === resolvedFieldId));
+    });
     // Prefer project-specific bundle (independent copy); fall back to global field bundle.
-    const bundleId = matched?.bundle?.id || matched?.field?.bundle?.id;
-;
+    // Also use bundleId returned directly by the App SDK if the REST API match failed.
+    const bundleId = matched?.bundle?.id || matched?.field?.bundle?.id || resolvedBundleId;
     if (!bundleId) { return; }
 
     // Step 2: fetch all elements with explicit $top=1000 (YouTrack's implicit cap is ~42).
@@ -262,6 +293,24 @@ export class API {
       `admin/customFieldSettings/bundles/version/${encodeURIComponent(bundleId)}/values/${encodeURIComponent(elementId)}?fields=id,name,releaseDate,startDate,released`,
       { method: 'POST', body }
     );
+  }
+
+  /** Returns version-bundle custom fields for the current project with canonical and localised names. */
+  async listProjectVersionFields(): Promise<Array<{ name: string; localizedName: string | null }>> {
+    const projectId = YTApp.entity?.type === 'project' ? (YTApp.entity.id || '') : '';
+    if (!projectId) { return []; }
+    try {
+      const fields = await this.host.fetchYouTrack<Array<{
+        field: { name: string; localizedName?: string | null; fieldType?: { id?: string } | null; bundle?: { id: string } | null } | null;
+        bundle: { id: string } | null;
+      }>>(`admin/projects/${encodeURIComponent(projectId)}/customFields?fields=id,field(id,name,localizedName,fieldType(id),bundle(id)),bundle(id)&$top=1000`);
+      return (fields || [])
+        .filter(f => f.bundle?.id || f.field?.bundle?.id) // only bundle-type fields
+        .map(f => ({ name: f.field?.name ?? '', localizedName: f.field?.localizedName ?? null }))
+        .filter(f => f.name);
+    } catch {
+      return [];
+    }
   }
 
   async getVersionFieldValues(fieldName: string): Promise<{ fieldName: string; values: Array<{ name: string; releaseDate: string | null; startDate: string | null; isReleased: boolean; isArchived: boolean }> }> {

--- a/src/widgets/release-manager-page/components/form/fields/basic-info.tsx
+++ b/src/widgets/release-manager-page/components/form/fields/basic-info.tsx
@@ -48,7 +48,7 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
   const isCustomFieldMode = appConfig.customFieldsMapping && !!fieldName && useExistingFieldValues;
 
   // Version field options state
-  const [versionOptions, setVersionOptions] = useState<Array<{name: string; releaseDate: string | null; isReleased: boolean; isArchived: boolean}>>([]);
+  const [versionOptions, setVersionOptions] = useState<Array<{name: string; releaseDate: string | null; startDate: string | null; isReleased: boolean; isArchived: boolean}>>([]);
   const [versionMode, setVersionMode] = useState<VersionMode>('select');
 
   // Fetch version field values when custom field mode is active
@@ -156,11 +156,14 @@ const BasicInfo: React.FC<BasicInfoProps> = ({
     } as React.ChangeEvent<HTMLInputElement>;
     handleInputChange(syntheticEvent);
 
-    // Auto-set release date from custom field value if present
+    // Auto-set release date and feature freeze date from custom field value if present
     if (selected) {
       const match = versionOptions.find(v => v.name === selected.key);
       if (match?.releaseDate) {
         handleDateChange('releaseDate')(new Date(match.releaseDate));
+      }
+      if (match?.startDate) {
+        handleDateChange('featureFreezeDate')(new Date(match.startDate));
       }
     }
   }, [handleInputChange, handleDateChange, versionOptions]);

--- a/src/widgets/release-manager-page/components/settings/custom-field-mapping.tsx
+++ b/src/widgets/release-manager-page/components/settings/custom-field-mapping.tsx
@@ -1,17 +1,36 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Input from '@jetbrains/ring-ui-built/components/input/input';
 import Checkbox from '@jetbrains/ring-ui-built/components/checkbox/checkbox';
 import {H3} from '@jetbrains/ring-ui-built/components/heading/heading';
 import Tooltip from '@jetbrains/ring-ui-built/components/tooltip/tooltip';
 import {AppSettings} from '../../interfaces';
+import {API} from '../../api';
 
 interface Props {
   settings: AppSettings;
   setSettings: React.Dispatch<React.SetStateAction<AppSettings>>;
+  api: API;
 }
 
-export const CustomFieldMapping: React.FC<Props> = ({ settings, setSettings }) => {
+export const CustomFieldMapping: React.FC<Props> = ({ settings, setSettings, api }) => {
   const mapping = settings.customFieldMapping;
+  const [availableFields, setAvailableFields] = useState<Array<{ name: string; localizedName: string | null }>>([]);
+  const [fieldsLoaded, setFieldsLoaded] = useState(false);
+
+  useEffect(() => {
+    api.listProjectVersionFields().then(fields => {
+      setAvailableFields(fields);
+      setFieldsLoaded(true);
+    }).catch(() => setFieldsLoaded(true));
+  }, [api]);
+
+  const configuredName = mapping?.plannedReleaseField || '';
+  const lowerConfigured = configuredName.toLowerCase();
+  const fieldMatch = availableFields.find(f =>
+    f.name.toLowerCase() === lowerConfigured ||
+    (f.localizedName && f.localizedName.toLowerCase() === lowerConfigured)
+  );
+  const showMismatchHint = fieldsLoaded && configuredName && !fieldMatch && availableFields.length > 0;
 
   return (
     <div className="settings-field custom-field-mapping">
@@ -34,7 +53,7 @@ export const CustomFieldMapping: React.FC<Props> = ({ settings, setSettings }) =
       <label className={'bold-label'} htmlFor="plannedReleaseField">Release Field</label>
       <Input
         id="plannedReleaseField"
-        value={mapping?.plannedReleaseField || ''}
+        value={configuredName}
         onChange={e => {
           const value = e.target.value;
           setSettings(prev => ({
@@ -45,8 +64,40 @@ export const CustomFieldMapping: React.FC<Props> = ({ settings, setSettings }) =
             }
           }));
         }}
-        placeholder="e.g., Release Version"
+        placeholder="e.g., Fix versions"
       />
+
+      {showMismatchHint && (
+        <div className="field-help" style={{ marginTop: '4px', padding: '6px 8px', backgroundColor: '#fff8e1', borderLeft: '3px solid #ff9800', color: '#5d4037' }}>
+          <strong>⚠️ Field not found.</strong> Enter the REST API name, not the localised display name.
+          {availableFields.length > 0 && (
+            <>
+              {' '}Available bundle fields:
+              <ul style={{ margin: '4px 0 0 16px', padding: 0 }}>
+                {availableFields.map(f => (
+                  <li key={f.name} style={{ cursor: 'pointer', textDecoration: 'underline' }}
+                    onClick={() => setSettings(prev => ({
+                      ...prev,
+                      customFieldMapping: { ...prev.customFieldMapping, plannedReleaseField: f.name }
+                    }))}>
+                    <strong>{f.name}</strong>
+                    {f.localizedName && f.localizedName !== f.name && (
+                      <span style={{ color: '#888', marginLeft: 4 }}>({f.localizedName})</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+
+      {fieldMatch && fieldMatch.localizedName && fieldMatch.localizedName !== fieldMatch.name && (
+        <div className="field-help" style={{ marginTop: '4px', color: '#888' }}>
+          Localised as &ldquo;{fieldMatch.localizedName}&rdquo; in your YouTrack instance.
+        </div>
+      )}
+
       <div className="field-help">Name of the custom field that stores the planned release value.</div>
 
       {mapping?.plannedReleaseField && (

--- a/src/widgets/release-manager-page/components/settings/settings-form.tsx
+++ b/src/widgets/release-manager-page/components/settings/settings-form.tsx
@@ -168,7 +168,7 @@ export const SettingsForm: React.FC<AppSettingsFormProps> = ({ onClose, onOpenIm
                 <>
                   <div className="settings-separator" role="separator" aria-orientation="vertical"/>
                   <div className="settings-column right">
-                    <CustomFieldMapping settings={settings} setSettings={setSettings}/>
+                    <CustomFieldMapping settings={settings} setSettings={setSettings} api={api}/>
                     {settings.customFieldMapping?.plannedReleaseField && (
                       <>
                         <div className="settings-separator horizontal" role="separator" aria-orientation="horizontal"/>


### PR DESCRIPTION
## Summary

- **Localised field name mismatch** — on YouTrack instances where a bundle field has a canonical REST API name (e.g. `Fix versions`) but displays in a different locale (e.g. German `Beheben in`), `syncVersionBundleElement` failed to find the field and silently skipped the date/released sync. Fixed by requesting `localizedName` in the REST API projection and matching against it, with a further fallback to field ID via a new `GET /field-bundle-info` backend endpoint that uses the App SDK's locale-aware `findFieldByName`.
- **Settings validation** — the Custom Field Mapping settings panel now loads available bundle fields on mount and shows a warning with clickable canonical-name suggestions when the configured name does not match any project field.
- **Feature Freeze Date not imported** — when creating a release version by selecting an existing CF bundle value, `startDate` was present in the API response but the `versionOptions` state type omitted it and `handleVersionSelect` never read it. Added `startDate` to the type and added the matching `handleDateChange('featureFreezeDate')` call alongside the existing `releaseDate` auto-fill.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)